### PR TITLE
Add default value for prefLang

### DIFF
--- a/src/webparts/submitTicket/SubmitTicketWebPart.manifest.json
+++ b/src/webparts/submitTicket/SubmitTicketWebPart.manifest.json
@@ -21,7 +21,8 @@
     "description": { "default": "SubmitTicket description" },
     "officeFabricIconFontName": "Page",
     "properties": {
-      "description": "SubmitTicket"
+      "description": "SubmitTicket",
+      "prefLang": "account"
     }
   }]
 }


### PR DESCRIPTION
Adding the default properties value to prefLang so when we access the webpart setting we saw account as the default setting instead of nothing. 

This do not change the functionality, it just add a visual to what it's selected by default.